### PR TITLE
Use Groovy's Property Access

### DIFF
--- a/jupyter/src/main/groovy/ai/stainless/micronaut/jupyter/KernelManager.groovy
+++ b/jupyter/src/main/groovy/ai/stainless/micronaut/jupyter/KernelManager.groovy
@@ -35,7 +35,7 @@ public class KernelManager {
 
     }
 
-    private Class kernelClass = Micronaut
+    Class kernelClass = Micronaut
     private List<Thread> kernelThreads = []
     private List<Kernel> kernelInstances = []
 
@@ -111,14 +111,6 @@ public class KernelManager {
             }
 
         }
-    }
-
-    public Class getKernelClass() {
-        return kernelClass
-    }
-
-    public void setKernelClass(Class kernelClass) {
-        this.kernelClass = kernelClass
     }
 
     public List<Kernel> getKernelInstances() {

--- a/jupyter/src/main/groovy/ai/stainless/micronaut/jupyter/kernel/Micronaut.groovy
+++ b/jupyter/src/main/groovy/ai/stainless/micronaut/jupyter/kernel/Micronaut.groovy
@@ -28,7 +28,7 @@ public class Micronaut extends Groovy {
     private TrackableKernelSocketsFactory kernelSocketsFactory
     private MicronautEvaluator evaluator
 
-    private ApplicationContext applicationContext
+    ApplicationContext applicationContext
 
     public Micronaut (
         final String id,
@@ -72,14 +72,6 @@ public class Micronaut extends Groovy {
             }
             catch (NoSuchMethodError e) { }
         }
-    }
-
-    public ApplicationContext getApplicationContext() {
-        return applicationContext
-    }
-
-    public void setApplicationContext(ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext
     }
 
     /*

--- a/jupyter/src/main/groovy/ai/stainless/micronaut/jupyter/kernel/MicronautEvaluator.groovy
+++ b/jupyter/src/main/groovy/ai/stainless/micronaut/jupyter/kernel/MicronautEvaluator.groovy
@@ -62,7 +62,7 @@ public class MicronautEvaluator extends GroovyEvaluator {
     private GroovyAutocomplete gac;
 
     private Boolean loaded = false
-    private Micronaut kernel
+    Micronaut kernel
 
     public MicronautEvaluator(
         String id,
@@ -206,13 +206,6 @@ public class MicronautEvaluator extends GroovyEvaluator {
         return scriptBinding;
     }
 
-    public Micronaut getKernel() {
-        return kernel
-    }
-
-    public void setKernel(Micronaut kernel) {
-        this.kernel = kernel
-    }
 /*
      * Custom implementation of GroovyClassLoaderFactory methods that use
      * custom compiler config

--- a/jupyter/src/main/groovy/ai/stainless/micronaut/jupyter/kernel/MicronautJupyterScript.groovy
+++ b/jupyter/src/main/groovy/ai/stainless/micronaut/jupyter/kernel/MicronautJupyterScript.groovy
@@ -6,19 +6,11 @@ import io.micronaut.context.ApplicationContext
 //@Slf4j
 public abstract class MicronautJupyterScript extends Script {
 
-    private ApplicationContext applicationContext
+    ApplicationContext applicationContext
 
     public MicronautJupyterScript () {
         //log.debug "Creating new jupyter script instance with binding: $binding"
         setBindingInstanceVariables(binding)
-    }
-
-    public ApplicationContext getApplicationContext() {
-        return applicationContext
-    }
-
-    public void setApplicationContext(ApplicationContext applicationContext) {
-        this.applicationContext = applicationContext
     }
 
     private void setBindingInstanceVariables (Binding scriptBinding) {


### PR DESCRIPTION
In Groovy when you define a property like `ApplicationContext applicationContext` (as opposed to `private ApplicationContext applicationContext`), that results in a private field being created and  corresponding public getter and setter methods that do just what these methods do.  These getters and setters can be eliminated from the source code and they will still be in the generated bytecode.